### PR TITLE
support ep.done(function (err, data1, data2) {})

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TESTS = test/test.js
 REPORTER = spec
-TIMEOUT = 2000
+TIMEOUT = 10000
 JSCOVERAGE = ./node_modules/jscover/bin/jscover
 
 test:

--- a/lib/eventproxy.js
+++ b/lib/eventproxy.js
@@ -394,11 +394,20 @@
       if (err) {
         return that.emit('error', err);
       }
-      if (typeof handler === 'function') {
+
+      // getAsync(query, ep.done('query'));
+      if (typeof handler === 'string') {
+        return that.emit(handler, data);
+      }
+
+      // speed improve for mostly case: `callback(err, data)`
+      if (arguments.length <= 2) {
         return handler(data);
       }
-      var eventname = handler;
-      that.emit(eventname, data);
+
+      // callback(err, args1, args2, ...)
+      var args = Array.prototype.slice.call(arguments, 1);
+      handler.apply(null, args);
     };
   };
 


### PR DESCRIPTION
如果异步请求返回的数据是多个参数的，也需要支持。实际应用中，还是会出现多个返回值的。
