### PR TITLE
裁减all与tail方法的体积

### DIFF
--- a/lib/eventproxy.js
+++ b/lib/eventproxy.js
@@ -245,9 +245,8 @@
    * @param {Function} callback Callback, that will be called after predefined events were fired.
    */
   EventProxy.prototype.all = function (eventname1, eventname2, callback) {
-    var args = Array.prototype.concat.apply([], arguments);
-    args.push(true);
-    _assign.apply(this, args);
+    Array.prototype.push.call(arguments, true);
+    _assign.apply(this, arguments);
     return this;
   };
   /**
@@ -282,9 +281,8 @@
    * @param {Function} callback Callback, that will be called after predefined events were fired.
    */
   EventProxy.prototype.tail = function () {
-    var args = Array.prototype.concat.apply([], arguments);
-    args.push(false);
-    _assign.apply(this, args);
+    Array.prototype.push.call(arguments, false);
+    _assign.apply(this, arguments);
     return this;
   };
   /**


### PR DESCRIPTION
此外还有一个更好的方法，使用var ARRAY = []; 然后ARRAY代替库中 的所有Array.prototype
