### PR TITLE
添加ep.done(event, fn)设计

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-EventProxy [![Build Status](https://secure.travis-ci.org/JacksonTian/eventproxy.png)](http://travis-ci.org/JacksonTian/eventproxy)
+EventProxy [![Build Status](https://secure.travis-ci.org/JacksonTian/eventproxy.png)](http://travis-ci.org/JacksonTian/eventproxy) [English Doc](https://github.com/JacksonTian/eventproxy/blob/master/README_en.md)
 ======
 
 > 这个世界上不存在所谓回调函数深度嵌套的问题。 —— [Jackson Tian](http://weibo.com/shyvo)

--- a/lib/eventproxy.js
+++ b/lib/eventproxy.js
@@ -432,19 +432,37 @@
    * });
    * ```
    *
+   * ```js
+   * fs.readFile('foo.txt', ep.done('content', function (content) {
+   *   return content.trim();
+   * }));
+   *
+   * // equal to =>
+   *
+   * fs.readFile('foo.txt', function (err, content) {
+   *   if (err) {
+   *     return ep.emit('error', err);
+   *   }
+   *   ep.emit('content', content.trim());
+   * });
+   * ```
    * @param {Function|String} handler, success callback or event name will be emit after callback.
    * @return {Function}
    */
-  EventProxy.prototype.done = function (handler) {
+  EventProxy.prototype.done = function (handler, callback) {
     var that = this;
     return function (err, data) {
       if (err) {
         return that.emit('error', err);
       }
 
-      // getAsync(query, ep.done('query'));
       if (typeof handler === 'string') {
-        return that.emit(handler, data);
+        // getAsync(query, ep.done('query'));
+        // or
+        // getAsync(query, ep.done('query', function (data) {
+        //   return data.trim();
+        // }));
+        return that.emit(handler,  callback ? callback.call(data) : data);
       }
 
       // speed improve for mostly case: `callback(err, data)`

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "type": "git",
     "url": "git://github.com/JacksonTian/eventproxy.git"
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "index.js",
   "directories": {
     "doc": "doc",

--- a/test/test.js
+++ b/test/test.js
@@ -293,7 +293,7 @@ describe("EventProxy", function () {
     assert.deepEqual(counter, 2, 'counter should be incremented.');
   });
 
-  it('done', function () {
+  it('done(fn)', function () {
     var ep = EventProxy.create();
     var counter = 0;
     var done = function (num) {
@@ -305,6 +305,30 @@ describe("EventProxy", function () {
     assert.deepEqual(counter, 1, 'counter should be incremented.');
     ep.trigger('event1', null, 2);
     assert.deepEqual(counter, 3, 'counter should be incremented.');
+  });
+
+  it('done(event)', function (done) {
+    var ep = EventProxy.create();
+    var counter = 0;
+    ep.bind('event1', function (data) {
+      should.exist(data);
+      done();
+    });
+    ep.bind('error', done);
+    fs.readFile(__filename, ep.done('event1'));
+  });
+
+  it('done(event, fn)', function (done) {
+    var ep = EventProxy.create();
+    ep.bind('event1', function (data) {
+      should.exist(data);
+      assert.deepEqual(data, 'hehe', 'data should be modified');
+      done();
+    });
+    ep.bind('error', done);
+    fs.readFile(__filename, ep.done('event1', function (data) {
+      return 'hehe';
+    }));
   });
 
   describe('errorHandler mode', function () {
@@ -390,6 +414,5 @@ describe("EventProxy", function () {
         done();
       });
     });
-
   });
 });


### PR DESCRIPTION
最简洁的方式当然就是`ep.done(event)`。但是有时候需要处理下得到的数据，我们原来的方法是

```
ep.done(function (data) {
  // TODO 处理数据
  ep.emit('event', newdata);
});
```

这个地方没有收敛好的在于还需要继续手工emit。

所以继续收敛：

```
ep.done('event', function (data) {
  // TODO 处理数据
  return newdata;
});
```

这个方式唯独还是不能处理一个事件传递多个数据的情况，不过比前一种好。传递多个数据还是继续手工emit吧。
