### PR TITLE
Add some JSDoc

### DIFF
--- a/lib/eventproxy.js
+++ b/lib/eventproxy.js
@@ -35,6 +35,7 @@
    * proxy.trigger("template", template);
    * proxy.trigger("l10n", resources);
    * ```
+   * @constructor
    */
   var EventProxy = function () {
     if (!(this instanceof EventProxy)) {
@@ -42,6 +43,7 @@
     }
     this._callbacks = {};
     this._fired = {};
+    return this;
   };
 
   /**
@@ -49,11 +51,12 @@
    * Passing `all` will bind the callback to all events fired.
    * @param {String} eventName Event name.
    * @param {Function} callback Callback.
+   * @returns {EventProxy} EventProxy instance
    */
-  EventProxy.prototype.addListener = function (ev, callback) {
+  EventProxy.prototype.addListener = function (eventName, callback) {
     this._callbacks = this._callbacks || {};
-    this._callbacks[ev] = this._callbacks[ev] || [];
-    this._callbacks[ev].push(callback);
+    this._callbacks[eventName] = this._callbacks[eventName] || [];
+    this._callbacks[eventName].push(callback);
     return this;
   };
   /**
@@ -73,8 +76,9 @@
    * Remove one or many callbacks. If `callback` is null, removes all callbacks for the event.
    * If `ev` is null, removes all bound callbacks
    * for all events.
-   * @param {String} eventName Event name.
+   * @param {String} ev Event name.
    * @param {Function} callback Callback.
+   * @returns {EventProxy} EventProxy instance
    */
   EventProxy.prototype.removeListener = function (ev, callback) {
     var calls = this._callbacks, i, l;
@@ -108,6 +112,7 @@
    * Remove all listeners. It equals unbind()
    * Just add this API for as same as Event.Emitter.
    * @param {String} event Event name.
+   * @returns {EventProxy} EventProxy instance
    */
   EventProxy.prototype.removeAllListeners = function (event) {
     return this.unbind(event);
@@ -118,7 +123,8 @@
    * same arguments as `trigger` is, apart from the event name.
    * Listening for `"all"` passes the true event name as the first argument.
    * @param {String} eventName Event name
-   * @param {Mix} data Pass in data
+   * @param {*} data Pass in data
+   * @returns {EventProxy} EventProxy instance
    */
   EventProxy.prototype.trigger = function (eventName, data) {
     var list, ev, callback, args, i, l;
@@ -171,6 +177,7 @@
    * Bind an event like the bind method, but will remove the listener after it was fired.
    * @param {String} ev Event name
    * @param {Function} callback Callback
+   * @returns {EventProxy} EventProxy instance
    */
   EventProxy.prototype.once = function (ev, callback) {
     var self = this;
@@ -186,7 +193,8 @@
    * Bind an event, and trigger it immediately.
    * @param {String} ev Event name.
    * @param {Function} callback Callback.
-   * @param {Mix} data The data that will be passed to calback as arguments.
+   * @param {*} data The data that will be passed to calback as arguments.
+   * @returns {EventProxy} EventProxy instance
    */
   EventProxy.prototype.immediate = function (ev, callback, data) {
     this.bind(ev, callback);
@@ -198,6 +206,9 @@
    */
   EventProxy.prototype.asap = EventProxy.prototype.immediate;
 
+  /**
+   * @this {EventProxy} This outter EventProxy object.
+   */
   var _assign = function (eventname1, eventname2, cb, once) {
     var proxy = this, length, index = 0, argsLength = arguments.length,
       bind, _all,
@@ -205,7 +216,7 @@
 
     // Check the arguments length.
     if (argsLength < 3) {
-      return this;
+      return;
     }
 
     events = Array.prototype.slice.apply(arguments, [0, argsLength - 2]);
@@ -214,7 +225,7 @@
 
     // Check the callback type.
     if (typeof callback !== "function") {
-      return this;
+      return;
     }
 
     length = events.length;
@@ -261,11 +272,11 @@
    * proxy.all([ev1, ev2], callback);
    * proxy.all(ev1, [ev2, ev3], callback);
    * ```
-   * @param {String} eventName1 First event name.
-   * @param {String} eventName2 Second event name.
+   * @param {...String} varEventNames Variable length of event names.
    * @param {Function} callback Callback, that will be called after predefined events were fired.
+   * @returns {EventProxy} EventProxy instance
    */
-  EventProxy.prototype.all = function (eventname1, eventname2, callback) {
+  EventProxy.prototype.all = function (varEventNames, callback) {
     var args = Array.prototype.concat.apply([], arguments);
     args.push(true);
     _assign.apply(this, args);
@@ -278,7 +289,8 @@
 
   /**
    * Assign the only one 'error' event handler.
-   * @param {Function(err)} callback
+   * @param {function(err)} callback
+   * @returns {EventProxy} EventProxy instance
    */
   EventProxy.prototype.fail = function (callback) {
     var that = this;
@@ -298,11 +310,11 @@
    * proxy.tail([ev1, ev2], callback);
    * proxy.tail(ev1, [ev2, ev3], callback);
    * ```
-   * @param {String} eventName1 First event name.
-   * @param {String} eventName2 Second event name.
+   * @param {...String} varEventNames Variable length of event names.
    * @param {Function} callback Callback, that will be called after predefined events were fired.
+   * @returns {EventProxy} EventProxy instance
    */
-  EventProxy.prototype.tail = function () {
+  EventProxy.prototype.tail = function (varEventNames, callback) {
     var args = Array.prototype.concat.apply([], arguments);
     args.push(false);
     _assign.apply(this, args);
@@ -322,6 +334,7 @@
    * @param {String} eventName Event name.
    * @param {Number} times N times.
    * @param {Function} callback Callback, that will be called after event was fired N times.
+   * @returns {EventProxy} EventProxy instance
    */
   EventProxy.prototype.after = function (eventName, times, callback) {
     if (times === 0) {
@@ -374,6 +387,7 @@
    * ```
    * @param {String} eventName Event name, shoule keep consistent with `after`.
    * @param {Function} callback Callback function, should return the final result.
+   * @returns {function(err, data)}
    */
   EventProxy.prototype.group = function (eventName, callback) {
     var that = this;
@@ -384,7 +398,7 @@
       if (err) {
         return that.emit('error', err);
       }
-      that.emit(group, {
+      return that.emit(group, {
         index: index,
         result: callback ? callback(data) : data
       });
@@ -393,11 +407,10 @@
 
   /**
    * The callback will be executed after any registered event was fired. It only executed once.
-   * @param {String} eventName1 Event name.
-   * @param {String} eventName2 Event name.
+   * @param {...String} varEventNames Variable length of event names.
    * @param {Function} callback The callback will get a map that has data and eventName attributes.
    */
-  EventProxy.prototype.any = function () {
+  EventProxy.prototype.any = function (varEventNames, callback) {
     var proxy = this,
       index,
       _bind,
@@ -464,8 +477,9 @@
    *   ep.emit('content', content.trim());
    * });
    * ```
-   * @param {Function|String} handler, success callback or event name will be emit after callback.
-   * @return {Function}
+   * @param {Function|String} handler success callback or event name will be emit after callback.
+   * @param {Function=} callback Optional success callback.
+   * @return {function(err, data)}
    */
   EventProxy.prototype.done = function (handler, callback) {
     var that = this;
@@ -492,12 +506,15 @@
       }
 
       // callback(err, args1, args2, ...)
-      handler.apply(null, args);
+      return handler.apply(null, args);
     };
   };
 
   /**
    * make done async
+   * @param {Function|String} handler
+   * @param {Function=} callback
+   * @return {function(err, data)}
    */
   EventProxy.prototype.doneLater = function (handler, callback) {
     var _doneHandler = this.done(handler, callback);


### PR DESCRIPTION
构造函数尾部也应该添加`return this`，不引起任何歧义
`@param`后面的参数名字要和实际参数名字一致
只有不返回任何值的函数才不需要`@returns`
不限制类型应该写作`{*}`而不是`{Mix}`
`_assign`自始至终就不该返回任何值，否则前面的if中返回`this`，后面返回`undefined`，就不一致了，容易出问题
`_assign`应该指明其中的`this`将会是什么值
如果在JSDoc中声明了function的具体签名，那要用小写
JSDoc中类型描述参考 https://developers.google.com/closure/compiler/docs/js-for-compiler
