### PR TITLE
Add headbind method to make callback excuted first.

### DIFF
--- a/lib/eventproxy.js
+++ b/lib/eventproxy.js
@@ -78,6 +78,17 @@
   EventProxy.prototype.subscribe = EventProxy.prototype.addListener;
 
   /**
+   * Bind an event, but put the callback into head of all callbacks.
+   * @param {String} eventName Event name.
+   * @param {Function} callback Callback.
+   */
+  EventProxy.prototype.headbind = function (ev, callback) {
+    debug('Add listener for %s', ev);
+    this._callbacks[ev] = this._callbacks[ev] || [];
+    this._callbacks[ev].unshift(callback);
+    return this;
+  };
+  /**
    * Remove one or many callbacks.
    *
    * - If `callback` is null, removes all callbacks for the event.

--- a/test/test.js
+++ b/test/test.js
@@ -105,6 +105,19 @@ describe("EventProxy", function () {
     assert.equal(counter, 1, 'counter should have only been incremented once.');
   });
 
+  it('headbind/trigger', function () {
+    var ep = EventProxy.create();
+    var str = '';
+    ep.bind("event", function (data) {
+      str += 'bind';
+    });
+    ep.headbind("event", function (data) {
+      str += 'headbind';
+    });
+    ep.trigger("event");
+    assert.equal(str, 'headbindbind', 'the callback that headbinded should execute first.');
+  });
+
   it('once/trigger', function () {
     var ep = EventProxy.create();
     var counter = 0;


### PR DESCRIPTION
一些场景下，callback中由于有状态的变化，导致下一个callback的执行不满足期望。
