### PR TITLE
Add spm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-EventProxy [![Build Status](https://secure.travis-ci.org/JacksonTian/eventproxy.png)](http://travis-ci.org/JacksonTian/eventproxy) [![NPM version](https://badge.fury.io/js/eventproxy.png)](http://badge.fury.io/js/eventproxy) [English Doc](https://github.com/JacksonTian/eventproxy/blob/master/README_en.md)
+EventProxy [![Build Status](https://secure.travis-ci.org/JacksonTian/eventproxy.png)](http://travis-ci.org/JacksonTian/eventproxy) [![NPM version](https://badge.fury.io/js/eventproxy.png)](http://badge.fury.io/js/eventproxy) [![spm package](http://spmjs.io/badge/eventproxy)](http://spmjs.io/package/eventproxy) [English Doc](https://github.com/JacksonTian/eventproxy/blob/master/README_en.md)
 ======
 
 [![NPM](https://nodei.co/npm/eventproxy.png?downloads=true&stars=true)](https://nodei.co/npm/eventproxy)
@@ -71,6 +71,12 @@ $ npm install eventproxy
 
 ```js
 var EventProxy = require('eventproxy');
+```
+
+### [spm](http://spmjs.io/package/eventproxy)
+
+```bash
+$ spm install eventproxy
 ```
 
 ### Component

--- a/README_en.md
+++ b/README_en.md
@@ -73,6 +73,12 @@ Usage:
 var EventProxy = require('eventproxy');
 ```
 
+### [spm](http://spmjs.io/package/eventproxy)
+
+```bash
+$ spm install eventproxy
+```
+
 ### For browser
 Following examples direct resource address of Github, and you can also download [resource file](https://raw.github.com/JacksonTian/eventproxy/master/lib/eventproxy.js) to your own project. 500 lines in total including comments and blank lines. To ensure the easy integrate with your project, EventProxy doesn't provide the minified version. You can use Uglify, YUI Compressor or Google Closure Complier to compress it.
 

--- a/package.json
+++ b/package.json
@@ -43,5 +43,9 @@
     "doc": "doc",
     "test": "test"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "spm": {
+    "main": "index.js",
+    "ignore": ["test"]
+  }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/eventproxy

---

It is a browser-side package manager popular in China, suppling a complete lifecycle managment of package via [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of eventproxy in spmjs, I can add it for your account after signing in http://spmjs.io.

spmjs/spm#781