### PR TITLE
Update eventproxy.js

### DIFF
--- a/lib/eventproxy.js
+++ b/lib/eventproxy.js
@@ -116,7 +116,7 @@
           for (var i = 0; i < l; i++) {
             if (callback === list[i]) {
               debug('Remove a listener of %s', eventname);
-              list[i] = null;
+              list.splice(i,1)
             }
           }
         }


### PR DESCRIPTION
119行，list[i]=null 不如 list.splice(i,1) 好吧。直接返回删除后的新callback数组
